### PR TITLE
RCLOUD-1196: Security update - axios

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rundeck/client",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Rundeck TypeScript SDK",
   "main": "dist/index.js",
   "browser": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@azure/ms-rest-js": "2.0.7",
     "@types/promise-queue": "^2.2.0",
-    "axios": "^0.21.3",
+    "axios": "^1.6.8",
     "promise-queue": "^2.2.5"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/rundeck/ts-rundeck"
   },
   "dependencies": {
-    "@azure/ms-rest-js": "2.0.7",
+    "@azure/ms-rest-js": "^2.7.0",
     "@types/promise-queue": "^2.2.0",
     "axios": "^1.6.8",
     "promise-queue": "^2.2.5"


### PR DESCRIPTION
Part of RCLOUD-1196 work, it's necessary to update Axios to the latest version.